### PR TITLE
Fixed setup to work with folders

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,5 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     py_modules=["fontio", "terminalio"],
-    packages=["displayio"]
+    packages=["displayio"],
 )

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
     keywords="adafruit blinka circuitpython micropython displayio lcd tft display pitft",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_modules=["displayio", "fontio", "terminalio"],
+    py_modules=["fontio", "terminalio"],
+    packages=["displayio"]
 )


### PR DESCRIPTION
Fixes #22. The issue was that setup.py was configured to only work with files and not folders. Tested by copying to the Pi and running `pip3 install .`