### PR TITLE
Divide by zero and speed up bug fixes

### DIFF
--- a/displayio/display.py
+++ b/displayio/display.py
@@ -213,6 +213,8 @@ class Display:
         When auto refresh is on, updates the display immediately. (The display will also
         update without calls to this.)
         """
+        self._subrectangles = []
+
         # Go through groups and and add each to buffer
         if self._current_group is not None:
             buffer = Image.new("RGBA", (self._width, self._height))
@@ -221,8 +223,9 @@ class Display:
             # save image to buffer (or probably refresh buffer so we can compare)
             self._buffer.paste(buffer)
 
-        # Eventually calculate dirty rectangles here
-        self._subrectangles.append(Rectangle(0, 0, self._width, self._height))
+        if self._current_group is not None:
+            # Eventually calculate dirty rectangles here
+            self._subrectangles.append(Rectangle(0, 0, self._width, self._height))
 
         for area in self._subrectangles:
             self._refresh_display_area(area)

--- a/displayio/tilegrid.py
+++ b/displayio/tilegrid.py
@@ -103,10 +103,10 @@ class TileGrid:
             tile_width = bitmap_width
         if tile_height is None:
             tile_height = bitmap_height
-        if bitmap_width % tile_width != 0:
+        if tile_width > 0 and bitmap_width % tile_width != 0:
             raise ValueError("Tile width must exactly divide bitmap width")
         self._tile_width = tile_width
-        if bitmap_height % tile_height != 0:
+        if tile_height > 0 and bitmap_height % tile_height != 0:
             raise ValueError("Tile height must exactly divide bitmap height")
         self._tile_height = tile_height
         if not 0 <= default_tile <= 255:

--- a/terminalio.py
+++ b/terminalio.py
@@ -37,6 +37,7 @@ terminalio for Blinka
 
 import sys  # pylint: disable=unused-import
 import fontio
+from displayio.tilegrid import TileGrid
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
@@ -46,3 +47,28 @@ FONT = fontio.BuiltinFont()
 # TODO: Tap into stdout to get the REPL
 # sys.stdout = open('out.dat', 'w')
 # sys.stdout.close()
+
+
+class Terminal:
+    """Displays text in a TileGrid
+
+    The terminalio module contains classes to display a character stream on a display. The built in font is available as terminalio.FONT.
+    """
+
+    def __init__(self, tilegrid, font):
+        if not isinstance(tilefrid, TileGrid):
+            raise TypeError("Expected a TileGrid")
+        self._tilegrid = tilegrid
+        if not isinstance(font, fontio.BuiltinFont):
+            raise TypeError("Expected a BuiltinFont")
+        self._font = font
+        self._cursor_x = 0
+        self._curcor_y = 0
+        self._first_row = 0
+        for x in range(self._tilegrid.width):
+            for y in range(self._tilegrid.height):
+                self._tilegrid[x, y] = 0
+
+    def write(self, buf):
+        """Write the buffer of bytes to the bus."""
+        pass

--- a/terminalio.py
+++ b/terminalio.py
@@ -37,7 +37,6 @@ terminalio for Blinka
 
 import sys  # pylint: disable=unused-import
 import fontio
-from displayio.tilegrid import TileGrid
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
@@ -47,28 +46,3 @@ FONT = fontio.BuiltinFont()
 # TODO: Tap into stdout to get the REPL
 # sys.stdout = open('out.dat', 'w')
 # sys.stdout.close()
-
-
-class Terminal:
-    """Displays text in a TileGrid
-
-    The terminalio module contains classes to display a character stream on a display. The built in font is available as terminalio.FONT.
-    """
-
-    def __init__(self, tilegrid, font):
-        if not isinstance(tilefrid, TileGrid):
-            raise TypeError("Expected a TileGrid")
-        self._tilegrid = tilegrid
-        if not isinstance(font, fontio.BuiltinFont):
-            raise TypeError("Expected a BuiltinFont")
-        self._font = font
-        self._cursor_x = 0
-        self._curcor_y = 0
-        self._first_row = 0
-        for x in range(self._tilegrid.width):
-            for y in range(self._tilegrid.height):
-                self._tilegrid[x, y] = 0
-
-    def write(self, buf):
-        """Write the buffer of bytes to the bus."""
-        pass


### PR DESCRIPTION
This fixes a divide by zero error when tilegrids are supplied 0,0 for the size (as spotted from a recent display text update) and also speeds up displayio significantly by fixing a bug that caused the display to accumulate dirty rectangles on each refresh.