### PR TITLE
Implement fill_row

### DIFF
--- a/displayio/display.py
+++ b/displayio/display.py
@@ -330,9 +330,21 @@ class Display:
         """Encode a postion into bytes."""
         return struct.pack(self._bounds_encoding, x, y)
 
+    def _rgb_tuple_to_rgb565(self, color_tuple):
+        return (
+            ((color_tuple[0] & 0x00F8) << 8)
+            | ((color_tuple[1] & 0x00FC) << 3)
+            | (color_tuple[2] & 0x00F8) >> 3
+        )
+
     def fill_row(self, y, buffer):
         """Extract the pixels from a single row"""
-        pass
+        for x in range(0, self._width):
+            _rgb_565 = self._rgb_tuple_to_rgb565(self._buffer.getpixel((x, y)))
+            buffer[x * 2] = _rgb_565 >> 8
+            buffer[x * 2 + 1] = _rgb_565
+            #(data[i * 2] << 8) + data[i * 2 + 1]
+        return buffer
 
     @property
     def auto_refresh(self):

--- a/displayio/display.py
+++ b/displayio/display.py
@@ -42,6 +42,7 @@ import digitalio
 from PIL import Image
 import numpy
 from recordclass import recordclass
+from displayio.colorconverter import ColorConverter
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
@@ -54,14 +55,6 @@ BACKLIGHT_PWM = 2
 
 # pylint: disable=unnecessary-pass, unused-argument
 # pylint: disable=too-many-instance-attributes
-
-
-def _rgb_tuple_to_rgb565(color_tuple):
-    return (
-        ((color_tuple[0] & 0x00F8) << 8)
-        | ((color_tuple[1] & 0x00FC) << 3)
-        | (color_tuple[2] & 0x00F8) >> 3
-    )
 
 
 class Display:
@@ -161,6 +154,7 @@ class Display:
         self._refresh_thread = None
         if self._auto_refresh:
             self.auto_refresh = True
+        self._colorconverter = ColorConverter()
 
         self._backlight_type = None
         if backlight_pin is not None:
@@ -342,7 +336,7 @@ class Display:
     def fill_row(self, y, buffer):
         """Extract the pixels from a single row"""
         for x in range(0, self._width):
-            _rgb_565 = _rgb_tuple_to_rgb565(self._buffer.getpixel((x, y)))
+            _rgb_565 = self._colorconverter.convert(self._buffer.getpixel((x, y)))
             buffer[x * 2] = (_rgb_565 >> 8) & 0xFF
             buffer[x * 2 + 1] = _rgb_565 & 0xFF
         return buffer

--- a/displayio/display.py
+++ b/displayio/display.py
@@ -343,7 +343,6 @@ class Display:
             _rgb_565 = self._rgb_tuple_to_rgb565(self._buffer.getpixel((x, y)))
             buffer[x * 2] = (_rgb_565 >> 8) & 0xff
             buffer[x * 2 + 1] = _rgb_565 & 0xff
-            #(data[i * 2] << 8) + data[i * 2 + 1]
         return buffer
 
     @property

--- a/displayio/display.py
+++ b/displayio/display.py
@@ -53,8 +53,17 @@ BACKLIGHT_IN_OUT = 1
 BACKLIGHT_PWM = 2
 
 # pylint: disable=unnecessary-pass, unused-argument
-
 # pylint: disable=too-many-instance-attributes
+
+
+def _rgb_tuple_to_rgb565(color_tuple):
+    return (
+        ((color_tuple[0] & 0x00F8) << 8)
+        | ((color_tuple[1] & 0x00FC) << 3)
+        | (color_tuple[2] & 0x00F8) >> 3
+    )
+
+
 class Display:
     """This initializes a display and connects it into CircuitPython. Unlike other objects
     in CircuitPython, Display objects live until ``displayio.release_displays()`` is called.
@@ -330,19 +339,12 @@ class Display:
         """Encode a postion into bytes."""
         return struct.pack(self._bounds_encoding, x, y)
 
-    def _rgb_tuple_to_rgb565(self, color_tuple):
-        return (
-            ((color_tuple[0] & 0x00F8) << 8)
-            | ((color_tuple[1] & 0x00FC) << 3)
-            | (color_tuple[2] & 0x00F8) >> 3
-        )
-
     def fill_row(self, y, buffer):
         """Extract the pixels from a single row"""
         for x in range(0, self._width):
-            _rgb_565 = self._rgb_tuple_to_rgb565(self._buffer.getpixel((x, y)))
-            buffer[x * 2] = (_rgb_565 >> 8) & 0xff
-            buffer[x * 2 + 1] = _rgb_565 & 0xff
+            _rgb_565 = _rgb_tuple_to_rgb565(self._buffer.getpixel((x, y)))
+            buffer[x * 2] = (_rgb_565 >> 8) & 0xFF
+            buffer[x * 2 + 1] = _rgb_565 & 0xFF
         return buffer
 
     @property

--- a/displayio/display.py
+++ b/displayio/display.py
@@ -341,8 +341,8 @@ class Display:
         """Extract the pixels from a single row"""
         for x in range(0, self._width):
             _rgb_565 = self._rgb_tuple_to_rgb565(self._buffer.getpixel((x, y)))
-            buffer[x * 2] = _rgb_565 >> 8
-            buffer[x * 2 + 1] = _rgb_565
+            buffer[x * 2] = (_rgb_565 >> 8) & 0xff
+            buffer[x * 2 + 1] = _rgb_565 & 0xff
             #(data[i * 2] << 8) + data[i * 2 + 1]
         return buffer
 


### PR DESCRIPTION
This implements the fill_row() function. Solves #12.

I tested by using the edited [BitmapSaver library from PR #12 on that repo](https://github.com/adafruit/Adafruit_CircuitPython_BitmapSaver/pull/12) and this code:
```python
import board
from adafruit_bitmapsaver import save_pixels
import displayio
import terminalio
from adafruit_display_text import label
import adafruit_ili9341

# Release any resources currently in use for the displays
displayio.release_displays()

spi = board.SPI()
tft_cs = board.CE0
tft_dc = board.D25

display_bus = displayio.FourWire(
    spi, command=tft_dc, chip_select=tft_cs, reset=board.D24
)
display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240)

text = "Hello world"
text_area = label.Label(terminalio.FONT, text=text)
text_area.x = 10
text_area.y = 10
display.show(text_area)


print("Taking Screenshot...")
save_pixels("/home/pi/screenshot.bmp", display)
print("Screenshot taken")

while True:
    pass

```