### PR TITLE
initial implementation of I2CDisplay class

### DIFF
--- a/displayio/i2cdisplay.py
+++ b/displayio/i2cdisplay.py
@@ -20,6 +20,9 @@ displayio for Blinka
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
+import time
+import digitalio
+
 
 class I2CDisplay:
     """Manage updating a display over I2C in the background while Python code runs.
@@ -68,15 +71,17 @@ class I2CDisplay:
         control_byte = 0b10000000 if is_command else 0b11000000
 
         buffer = []
-        for d in data:
+        for data_byte in data:
             buffer.append(control_byte)
-            buffer.append(d)
+            buffer.append(data_byte)
 
         self._i2c.writeto(self._dev_addr, bytes(buffer))
 
     def begin_transaction(self):
+        """Begin the I2C transaction"""
         while not self._i2c.try_lock():
             pass
 
     def end_transaction(self):
+        """End the I2C transaction"""
         self._i2c.unlock()

--- a/displayio/i2cdisplay.py
+++ b/displayio/i2cdisplay.py
@@ -54,14 +54,12 @@ class I2CDisplay:
             self._reset.deinit()
 
     def reset(self):
-        """Performs a hardware reset via the reset pin if one is present.
-        """
+        """Performs a hardware reset via the reset pin if one is present."""
         if self._reset is not None:
             self._reset.value = False
             time.sleep(0.001)
             self._reset.value = True
             time.sleep(0.001)
-
 
     def send(self, is_command, data, *, toggle_every_byte=False):
         """Sends the given command value followed by the full set of data. Display state,


### PR DESCRIPTION
If this actually works, I think it closes #2  ... I basically followed the `fourwire` class interface.  I then tested it on a 128x64 SSD1306 based OLED (https://www.adafruit.com/product/326), and while it does sucessfully talk to the OLED and do things like command the OLED on/off based on the init string, it's just blinking gibberish when I run any regular `displayio` code.  So I'm not confident this PR is actually right, hence the "draft" status.

That said, it's probably better than nothing!  And maybe I did something obviously wrong someone can point out to me to correct it?