### PR TITLE
Fix code duplication warnings

### DIFF
--- a/displayio/bitmap.py
+++ b/displayio/bitmap.py
@@ -53,8 +53,8 @@ class Bitmap:
         share the underlying Bitmap. value_count is used to minimize the memory used to store
         the Bitmap.
         """
-        self._width = width
-        self._height = height
+        self._bmp_width = width
+        self._bmp_height = height
         self._read_only = False
 
         if value_count < 0:
@@ -87,8 +87,8 @@ class Bitmap:
         if isinstance(index, (tuple, list)):
             x, y = index
         elif isinstance(index, int):
-            x = index % self._width
-            y = index // self._width
+            x = index % self._bmp_width
+            y = index // self._bmp_width
         else:
             raise TypeError("Index is not an int, list, or tuple")
 
@@ -106,10 +106,10 @@ class Bitmap:
         if isinstance(index, (tuple, list)):
             x = index[0]
             y = index[1]
-            index = y * self._width + x
+            index = y * self._bmp_width + x
         elif isinstance(index, int):
-            x = index % self._width
-            y = index // self._width
+            x = index % self._bmp_width
+            y = index // self._bmp_width
         self._image.putpixel((x, y), value)
         if self._dirty_area.x1 == self._dirty_area.x2:
             self._dirty_area.x1 = x
@@ -132,15 +132,15 @@ class Bitmap:
 
     def fill(self, value):
         """Fills the bitmap with the supplied palette index value."""
-        self._image = Image.new("P", (self._width, self._height), value)
-        self._dirty_area = Rectangle(0, 0, self._width, self._height)
+        self._image = Image.new("P", (self._bmp_width, self._bmp_height), value)
+        self._dirty_area = Rectangle(0, 0, self._bmp_width, self._bmp_height)
 
     @property
     def width(self):
         """Width of the bitmap. (read only)"""
-        return self._width
+        return self._bmp_width
 
     @property
     def height(self):
         """Height of the bitmap. (read only)"""
-        return self._height
+        return self._bmp_height

--- a/displayio/group.py
+++ b/displayio/group.py
@@ -59,9 +59,9 @@ class Group:
         if not isinstance(scale, int) or scale < 1:
             raise ValueError("Scale must be >= 1")
         self._scale = scale
-        self._x = x
-        self._y = y
-        self._hidden = False
+        self._group_x = x
+        self._group_y = y
+        self._hidden_group = False
         self._layers = []
         self._supported_types = (TileGrid, Group)
         self._absolute_transform = None
@@ -74,8 +74,8 @@ class Group:
         """Update the parent transform and child transforms"""
         self.in_group = parent_transform is not None
         if self.in_group:
-            x = self._x
-            y = self._y
+            x = self._group_x
+            y = self._group_y
             if parent_transform.transpose_xy:
                 x, y = y, x
             self._absolute_transform.x = parent_transform.x + parent_transform.dx * x
@@ -154,7 +154,7 @@ class Group:
         del self._layers[index]
 
     def _fill_area(self, buffer):
-        if self._hidden:
+        if self._hidden_group:
             return
 
         for layer in self._layers:
@@ -166,13 +166,13 @@ class Group:
         """True when the Group and all of it’s layers are not visible. When False, the
         Group’s layers are visible if they haven’t been hidden.
         """
-        return self._hidden
+        return self._hidden_group
 
     @hidden.setter
     def hidden(self, value):
         if not isinstance(value, (bool, int)):
             raise ValueError("Expecting a boolean or integer value")
-        self._hidden = bool(value)
+        self._hidden_group = bool(value)
 
     @property
     def scale(self):
@@ -201,37 +201,37 @@ class Group:
     @property
     def x(self):
         """X position of the Group in the parent."""
-        return self._x
+        return self._group_x
 
     @x.setter
     def x(self, value):
         if not isinstance(value, int):
             raise ValueError("x must be an integer")
-        if self._x != value:
+        if self._group_x != value:
             if self._absolute_transform.transpose_xy:
                 dy_value = self._absolute_transform.dy / self._scale
-                self._absolute_transform.y += dy_value * (value - self._x)
+                self._absolute_transform.y += dy_value * (value - self._group_x)
             else:
                 dx_value = self._absolute_transform.dx / self._scale
-                self._absolute_transform.x += dx_value * (value - self._x)
-            self._x = value
+                self._absolute_transform.x += dx_value * (value - self._group_x)
+            self._group_x = value
             self._update_child_transforms()
 
     @property
     def y(self):
         """Y position of the Group in the parent."""
-        return self._y
+        return self._group_y
 
     @y.setter
     def y(self, value):
         if not isinstance(value, int):
             raise ValueError("y must be an integer")
-        if self._y != value:
+        if self._group_y != value:
             if self._absolute_transform.transpose_xy:
                 dx_value = self._absolute_transform.dx / self._scale
-                self._absolute_transform.x += dx_value * (value - self._y)
+                self._absolute_transform.x += dx_value * (value - self._group_y)
             else:
                 dy_value = self._absolute_transform.dy / self._scale
-                self._absolute_transform.y += dy_value * (value - self._y)
-            self._y = value
+                self._absolute_transform.y += dy_value * (value - self._group_y)
+            self._group_y = value
             self._update_child_transforms()

--- a/displayio/i2cdisplay.py
+++ b/displayio/i2cdisplay.py
@@ -61,11 +61,11 @@ class I2CDisplay:
         """Performs a hardware reset via the reset pin. Raises an exception if called
         when no reset pin is available.
         """
-        pass
+        raise NotImplementedError("I2CDisplay reset has not been implemented yet")
 
     def send(self, command, data):
         """Sends the given command value followed by the full set of data. Display state,
         such as vertical scroll, set via send may or may not be reset once the code is
         done.
         """
-        pass
+        raise NotImplementedError("I2CDisplay send has not been implemented yet")

--- a/displayio/parallelbus.py
+++ b/displayio/parallelbus.py
@@ -67,7 +67,6 @@ class ParallelBus:
         """
         raise NotImplementedError("ParallelBus reset has not been implemented yet")
 
-
     def send(self, command, data):
         """Sends the given command value followed by the full set of data. Display state,
         such as vertical scroll, set via ``send`` may or may not be reset once the code is

--- a/displayio/parallelbus.py
+++ b/displayio/parallelbus.py
@@ -65,11 +65,12 @@ class ParallelBus:
         """Performs a hardware reset via the reset pin. Raises an exception if called when
         no reset pin is available.
         """
-        pass
+        raise NotImplementedError("ParallelBus reset has not been implemented yet")
+
 
     def send(self, command, data):
         """Sends the given command value followed by the full set of data. Display state,
         such as vertical scroll, set via ``send`` may or may not be reset once the code is
         done.
         """
-        pass
+        raise NotImplementedError("ParallelBus send has not been implemented yet")


### PR DESCRIPTION
Fixes #52. There was really only one area that I saw that actually benefited from removing duplicated code. I just changed private variable names or added NotImplemented errors for the rest. Either way, this shouldn't block folks anymore.