### PR TITLE
Change display use to bytes

### DIFF
--- a/displayio/display.py
+++ b/displayio/display.py
@@ -242,7 +242,7 @@ class Display:
             | (data[:, :, 2] >> 3)
         )
 
-        pixels = list(
+        pixels = bytes(
             numpy.dstack(((color >> 8) & 0xFF, color & 0xFF)).flatten().tolist()
         )
 


### PR DESCRIPTION
For #56. Simple change from `list` to `bytes`. Recreated original issue and confirmed this fix works.

This is saved as **tft_test.py**
```python
import time
import board
import busio
import displayio
from adafruit_featherwing import minitft_featherwing

i2c = board.I2C()
spi = busio.SPI(board.SCK1, board.MOSI1, board.MISO1)
fw = minitft_featherwing.MiniTFTFeatherWing(i2c=i2c, spi=spi, cs=board.GP15, dc=board.GP14)


bmp = displayio.Bitmap(160, 80, 2)

pal = displayio.Palette(2)
pal[0] = 0x000000
pal[1] = 0xffffff

tg = displayio.TileGrid(bmp, pixel_shader=pal)

splash = displayio.Group()
splash.append(tg)

fw.display.show(splash)

for x in range(40, 100):
    for y in range(30, 50):
        bmp[x, y] = 1
        
fw.display.refresh()
```

Running that with:
```
$ export BLINKA_U2IF=1
$ python3 tft_test.py
```
gets:

![tft_test](https://user-images.githubusercontent.com/8755041/119741733-2cdd9880-be3b-11eb-8493-ace793b56d04.jpg)
