### PR TITLE
continue if i2cdisplay failed to import

### DIFF
--- a/displayio/__init__.py
+++ b/displayio/__init__.py
@@ -23,7 +23,10 @@ from displayio.display import Display
 from displayio.epaperdisplay import EPaperDisplay
 from displayio.fourwire import FourWire
 from displayio.group import Group
-from displayio.i2cdisplay import I2CDisplay
+try:
+    from displayio.i2cdisplay import I2CDisplay
+except NotImplementedError:
+    print("WARNING: I2CDisplay is not supported on this device.")
 from displayio.ondiskbitmap import OnDiskBitmap
 from displayio.palette import Palette
 from displayio.parallelbus import ParallelBus

--- a/displayio/__init__.py
+++ b/displayio/__init__.py
@@ -23,6 +23,7 @@ from displayio.display import Display
 from displayio.epaperdisplay import EPaperDisplay
 from displayio.fourwire import FourWire
 from displayio.group import Group
+
 try:
     from displayio.i2cdisplay import I2CDisplay
 except NotImplementedError:

--- a/displayio/__init__.py
+++ b/displayio/__init__.py
@@ -23,11 +23,7 @@ from displayio.display import Display
 from displayio.epaperdisplay import EPaperDisplay
 from displayio.fourwire import FourWire
 from displayio.group import Group
-
-try:
-    from displayio.i2cdisplay import I2CDisplay
-except NotImplementedError:
-    print("WARNING: I2CDisplay is not supported on this device.")
+from displayio.i2cdisplay import I2CDisplay
 from displayio.ondiskbitmap import OnDiskBitmap
 from displayio.palette import Palette
 from displayio.parallelbus import ParallelBus

--- a/displayio/i2cdisplay.py
+++ b/displayio/i2cdisplay.py
@@ -23,16 +23,9 @@ displayio for Blinka
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
-
 import time
 import busio
 import digitalio
-import microcontroller
-
-try:
-    from typing import Optional
-except ImportError:
-    pass
 
 
 class I2CDisplay:
@@ -40,13 +33,7 @@ class I2CDisplay:
     It doesn’t handle display initialization.
     """
 
-    def __init__(
-        self,
-        i2c_bus: busio.I2C,
-        *,
-        device_address: int,
-        reset: Optional[microcontroller.Pin] = None
-    ):
+    def __init__(self, i2c_bus: busio.I2C, *, device_address: int, reset=None):
         """Create a I2CDisplay object associated with the given I2C bus and reset pin.
 
         The I2C bus and pins are then in use by the display until displayio.release_displays() is


### PR DESCRIPTION
this resolves #62 

By catching this exception we can allow much of the rest of the functionality of this library to work in environments that cannot successfully import `microcontroller` 