### PR TITLE
Add an internal _set_scale method

### DIFF
--- a/displayio/group.py
+++ b/displayio/group.py
@@ -46,10 +46,9 @@ class Group:
         self._hidden_group = False
         self._layers = []
         self._supported_types = (TileGrid, Group)
-        self._absolute_transform = None
         self.in_group = False
         self._absolute_transform = Transform(0, 0, 1, 1, 1, False, False, False)
-        self.scale = scale  # Set the scale via the setter
+        self._set_scale(scale)  # Set the scale via the setter
 
     def update_transform(self, parent_transform):
         """Update the parent transform and child transforms"""
@@ -164,6 +163,11 @@ class Group:
 
     @scale.setter
     def scale(self, value):
+        self._set_scale(value)
+
+    def _set_scale(self, value):
+        # This is method allows the scale to be set by this class even when
+        # the scale property is over-ridden by a subclass.
         if not isinstance(value, int) or value < 1:
             raise ValueError("Scale must be >= 1")
         if self._scale != value:


### PR DESCRIPTION
Add an internal _set_scale method, so that the scale can still be set from the constructor even when the scale property is over-ridden in a subclass.

Closes #64

This has been tested with the following code
```python
import displayio
import terminalio
from adafruit_display_text import label
from blinka_displayio_pygamedisplay import PyGameDisplay

display = PyGameDisplay(width=320, height=240)
splash = displayio.Group(max_size=10)
display.show(splash)

lbl = label.Label(font=terminalio.FONT, text="Hello World", scale=4, x=20, y=20)
splash.append(lbl)

while display.running:
    pass
```

It was also tested with the code in issue #60 and it still behaves correctly.