### PR TITLE
Update the constructor parameters of EPaperDisplay to match the core.

### DIFF
--- a/displayio/epaperdisplay.py
+++ b/displayio/epaperdisplay.py
@@ -49,7 +49,8 @@ class EPaperDisplay:
         rotation=0,
         set_column_window_command=None,
         set_row_window_command=None,
-        single_byte_bounds=False,
+        set_current_column_command=None,
+        set_current_row_command=None,
         write_black_ram_command,
         black_bits_inverted=False,
         write_color_ram_command=None,
@@ -60,7 +61,8 @@ class EPaperDisplay:
         busy_pin=None,
         busy_state=True,
         seconds_per_frame=180,
-        always_toggle_chip_select=False
+        always_toggle_chip_select=False,
+        grayscale=False,
     ):
         # pylint: disable=too-many-locals,unnecessary-pass
         """
@@ -73,6 +75,42 @@ class EPaperDisplay:
         next byte will be the delay time in milliseconds. The remaining 7 bits are the
         parameter count excluding any delay byte. The third through final bytes are the
         remaining command parameters. The next byte will begin a new command definition.
+
+
+        :param display_bus: The bus that the display is connected to
+        :type _DisplayBus: displayio.FourWire or displayio.ParallelBus
+        :param ~_typing.ReadableBuffer start_sequence: Byte-packed initialization sequence.
+        :param ~_typing.ReadableBuffer stop_sequence: Byte-packed initialization sequence.
+        :param int width: Width in pixels
+        :param int height: Height in pixels
+        :param int ram_width: RAM width in pixels
+        :param int ram_height: RAM height in pixels
+        :param int colstart: The index if the first visible column
+        :param int rowstart: The index if the first visible row
+        :param int rotation: The rotation of the display in degrees clockwise. Must be in
+            90 degree increments (0, 90, 180, 270)
+        :param int set_column_window_command: Command used to set the start and end columns
+            to update
+        :param int set_row_window_command: Command used so set the start and end rows to update
+        :param int set_current_column_command: Command used to set the current column location
+        :param int set_current_row_command: Command used to set the current row location
+        :param int write_black_ram_command: Command used to write pixels values into the update
+            region
+        :param bool black_bits_inverted: True if 0 bits are used to show black pixels. Otherwise,
+            1 means to show black.
+        :param int write_color_ram_command: Command used to write pixels values into the update
+            region
+        :param bool color_bits_inverted: True if 0 bits are used to show the color. Otherwise, 1
+            means to show color.
+        :param int highlight_color: RGB888 of source color to highlight with third ePaper color.
+        :param int refresh_display_command: Command used to start a display refresh
+        :param float refresh_time: Time it takes to refresh the display before the stop_sequence
+            should be sent. Ignored when busy_pin is provided.
+        :param microcontroller.Pin busy_pin: Pin used to signify the display is busy
+        :param bool busy_state: State of the busy pin when the display is busy
+        :param float seconds_per_frame: Minimum number of seconds between screen refreshes
+        :param bool always_toggle_chip_select: When True, chip select is toggled every byte
+        :param bool grayscale: When true, the color ram is the low bit of 2-bit grayscale
         """
         pass
 


### PR DESCRIPTION
As an aside, I have a three colour e-ink display on hand that I am going to try and get working with CircuitPython and Blinka on a Raspberry Pi 4.
https://shop.pimoroni.com/products/inky-phat?variant=12549254905939
It lists it as a SSD1608 in their documentation but I think that is for the two-colour variant. I'm hoping it's the SSD1680 in the three-colour.