### PR TITLE
return rgba888 value from palette getitem

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       id: repo-name
       run: |
         echo ::set-output name=repo-name::Adafruit-Blinka-displayio
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Versions
       run: |
         python3 --version

--- a/displayio/palette.py
+++ b/displayio/palette.py
@@ -82,7 +82,7 @@ class Palette:
     def __getitem__(self, index):
         if not 0 <= index < len(self._colors):
             raise ValueError("Palette index out of range")
-        return self._colors[index]
+        return self._colors[index]["rgb888"]
 
     def make_transparent(self, palette_index):
         """Set the palette index to be a transparent color"""

--- a/displayio/tilegrid.py
+++ b/displayio/tilegrid.py
@@ -179,7 +179,7 @@ class TileGrid:
 
     def _shade(self, pixel_value):
         if isinstance(self._pixel_shader, Palette):
-            return self._pixel_shader[pixel_value]["rgba"]
+            return self._pixel_shader[pixel_value]
         if isinstance(self._pixel_shader, ColorConverter):
             return self._pixel_shader.convert(pixel_value)
         return pixel_value

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ extensions = [
 # autodoc_mock_imports = ["digitalio", "busio"]
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.4", None),
+    "python": ("https://docs.python.org/3.7", None),
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,7 @@ setup(
         "Topic :: System :: Hardware",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.7",
     ],
     # What does your project relate to?
     keywords="adafruit blinka circuitpython micropython displayio lcd tft display pitft",


### PR DESCRIPTION
This change makes the behavior of `Palette.__getitem__()` the same as it is in core `displayio` returning the literal int rgb888 value instead of a dictionary containing that int and a few other fields.

I tested the change successfully on Raspberry Pi 3 B+ with an ili9341 display using a "hello world" simpletest, the simpletest from Display_Shapes library, and the SwitchRound simpletest from DisplayIO_Layout library. I also verified that `make_transparent()` on the Palette object works as expected with this changes.

Also tested successfully with SwitchRound simpletest and another self-contained palette item printing example on Linux PC with my PyGameDisplay library.