### PR TITLE
OnDiskBitmap.pixel_shader implementation

### DIFF
--- a/displayio/_ondiskbitmap.py
+++ b/displayio/_ondiskbitmap.py
@@ -47,7 +47,7 @@ class OnDiskBitmap:
 
     @property
     def pixel_shader(self) -> Union[ColorConverter, Palette]:
-        """Height of the bitmap. (read only)"""
+        """The ColorConverter or Palette for this image. (read only)"""
         return self._image.getpalette()
 
     def __getitem__(self, index: Union[tuple, list, int]) -> int:

--- a/displayio/_ondiskbitmap.py
+++ b/displayio/_ondiskbitmap.py
@@ -48,7 +48,7 @@ class OnDiskBitmap:
     @property
     def pixel_shader(self) -> Union[ColorConverter, Palette]:
         """Height of the bitmap. (read only)"""
-        return self._image.height
+        return self._image.getpalette()
 
     def __getitem__(self, index: Union[tuple, list, int]) -> int:
         """


### PR DESCRIPTION
Right now this property returns the image height instead of the palette or colorconverter. This changes to return the palette from the PIL Image object.