### PR TITLE
Fix for TypeError send data as command

### DIFF
--- a/displayio/_display.py
+++ b/displayio/_display.py
@@ -183,7 +183,7 @@ class Display:
         self._bus._begin_transaction()
         if self._data_as_commands:
             self._bus._send(
-                DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, bytes([command] + data)
+                DISPLAY_COMMAND, CHIP_SELECT_TOGGLE_EVERY_BYTE, bytes([command]) + data
             )
         else:
             self._bus._send(


### PR DESCRIPTION
I think this will resolve #77. However I have not tested the fix on hardware that needs it. I'm using a Pi 3 B+ with ili9341 display. With that environment I think it's not using data_as_command so it's not actually using this line of the driver.

Fix by moving the paren to only covert the command to bytes, then concatenate it with the data which is already type `bytes` 

Tested in python3 REPL on the Pi:
```python
Python 3.7.3 (default, Jul 25 2020, 13:03:44) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> data = b'\x00\x00\x00\xef'
>>> command = 43
>>> bytes([command]) + data
b'+\x00\x00\x00\xef'
```