### PR TITLE
Switch to pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,6 @@ jobs:
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
-    - name: Build assets
-      run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       id: repo-name
       run: |
         echo ::set-output name=repo-name::Adafruit-Blinka-displayio
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: "3.x"
     - name: Versions
       run: |
         python3 --version
@@ -39,14 +39,36 @@ jobs:
       # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |
         source actions-ci/install.sh
-    - name: Pip install pylint, black, & Sphinx
+    - name: Pip install Sphinx, pre-commit
       run: |
-        pip install --force-reinstall pylint black Sphinx sphinx-rtd-theme pre-commit
+        pip install --force-reinstall Sphinx sphinx-rtd-theme pre-commit
     - name: Library version
       run: git describe --dirty --always --tags
+    - name: Setup problem matchers
+      uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
+    - name: Build assets
+      run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
+    - name: Archive bundles
+      uses: actions/upload-artifact@v2
+      with:
+        name: bundles
+        path: ${{ github.workspace }}/bundles/
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
+    - name: Check For pyproject.toml
+      id: need-pypi
+      run: |
+        echo ::set-output name=pyproject-toml::$( find . -wholename './pyproject.toml' )
+    - name: Build Python package
+      if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
+      run: |
+        pip install --upgrade build twine
+        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+            sed -i -e "s/0.0.0+auto.0/1.2.3/" $file;
+        done;
+        python -m build
+        twine check dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,11 +49,6 @@ jobs:
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
-    - name: Archive bundles
-      uses: actions/upload-artifact@v2
-      with:
-        name: bundles
-        path: ${{ github.workspace }}/bundles/
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,25 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Check For setup.py
+    - name: Check For pyproject.toml
       id: need-pypi
       run: |
-        echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
+        echo ::set-output name=pyproject-toml::$( find . -wholename './pyproject.toml' )
     - name: Set up Python
-      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
-      uses: actions/setup-python@v1
+      if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install dependencies
-      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
+      if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install --upgrade build twine
     - name: Build and publish
-      if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
+      if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
       env:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
-        python setup.py sdist
+        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+            sed -i -e "s/0.0.0+auto.0/${{github.event.release.tag_name}}/" $file;
+        done;
+        python -m build
         twine upload dist/*

--- a/displayio/__init__.py
+++ b/displayio/__init__.py
@@ -33,7 +33,7 @@ from ._tilegrid import TileGrid
 from ._display import displays
 from ._displaybus import _DisplayBus
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_area.py
+++ b/displayio/_area.py
@@ -20,7 +20,7 @@ Area for Blinka Displayio
 
 from __future__ import annotations
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_Displayio.git"
 
 

--- a/displayio/_bitmap.py
+++ b/displayio/_bitmap.py
@@ -22,7 +22,7 @@ from typing import Union, Tuple
 from PIL import Image
 from ._structs import RectangleStruct
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_colorconverter.py
+++ b/displayio/_colorconverter.py
@@ -17,7 +17,7 @@ displayio for Blinka
 
 """
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 from ._colorspace import Colorspace

--- a/displayio/_colorspace.py
+++ b/displayio/_colorspace.py
@@ -18,7 +18,7 @@ displayio for Blinka
 
 """
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_constants.py
+++ b/displayio/_constants.py
@@ -6,7 +6,7 @@
 """Constants"""
 
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_Displayio.git"
 
 

--- a/displayio/_display.py
+++ b/displayio/_display.py
@@ -41,7 +41,7 @@ from ._constants import (
     BACKLIGHT_PWM,
 )
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 displays = []

--- a/displayio/_displaybus.py
+++ b/displayio/_displaybus.py
@@ -22,7 +22,7 @@ import paralleldisplay
 from ._fourwire import FourWire
 from ._i2cdisplay import I2CDisplay
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_Displayio.git"
 
 _DisplayBus = Union[FourWire, I2CDisplay, paralleldisplay.ParallelBus]

--- a/displayio/_displaycore.py
+++ b/displayio/_displaycore.py
@@ -18,7 +18,7 @@ Super class of the display classes
 
 """
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_Displayio.git"
 
 

--- a/displayio/_epaperdisplay.py
+++ b/displayio/_epaperdisplay.py
@@ -23,7 +23,7 @@ import circuitpython_typing
 from ._group import Group
 from ._displaybus import _DisplayBus
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_fourwire.py
+++ b/displayio/_fourwire.py
@@ -30,7 +30,7 @@ from ._constants import (
     DISPLAY_DATA,
 )
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_group.py
+++ b/displayio/_group.py
@@ -22,7 +22,7 @@ from typing import Union, Callable
 from ._structs import TransformStruct
 from ._tilegrid import TileGrid
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_i2cdisplay.py
+++ b/displayio/_i2cdisplay.py
@@ -26,7 +26,7 @@ import digitalio
 import circuitpython_typing
 from ._constants import CHIP_SELECT_UNTOUCHED, DISPLAY_COMMAND
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_ondiskbitmap.py
+++ b/displayio/_ondiskbitmap.py
@@ -22,7 +22,7 @@ from PIL import Image
 from ._colorconverter import ColorConverter
 from ._palette import Palette
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_palette.py
+++ b/displayio/_palette.py
@@ -20,7 +20,7 @@ displayio for Blinka
 from typing import Optional, Union, Tuple
 import circuitpython_typing
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_shape.py
+++ b/displayio/_shape.py
@@ -20,7 +20,7 @@ displayio for Blinka
 
 from ._bitmap import Bitmap
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/displayio/_structs.py
+++ b/displayio/_structs.py
@@ -19,7 +19,7 @@ Struct Data Classes for Blinka Displayio
 
 from dataclasses import dataclass
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_Displayio.git"
 
 

--- a/displayio/_tilegrid.py
+++ b/displayio/_tilegrid.py
@@ -26,7 +26,7 @@ from ._shape import Shape
 from ._palette import Palette
 from ._structs import RectangleStruct, TransformStruct
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ release = "1.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/fontio.py
+++ b/fontio.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     from typing_extensions import Protocol
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/paralleldisplay.py
+++ b/paralleldisplay.py
@@ -20,7 +20,7 @@ paralleldisplay for Blinka
 import microcontroller
 import circuitpython_typing
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2022 Alec Delaney for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "setuptools-scm",
+]
+
+[project]
+name = "adafruit-blinka-displayio"
+description = "displayio for Blinka"
+version = "0.0.0+auto.0"
+readme = "README.rst"
+authors = [
+    {name = "Adafruit Industries", email = "circuitpython@adafruit.com"}
+]
+urls = {Homepage = "https://github.com/adafruit/Adafruit_CircuitPython_SI1145.git"}
+keywords = [
+    "adafruit",
+    "blinka",
+    "circuitpython",
+    "micropython",
+    "displayio",
+    "lcd",
+    "tft",
+    "display",
+    "pitft",
+]
+license = {text = "MIT"}
+classifiers = [
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Embedded Systems",
+    "Topic :: System :: Hardware",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+dynamic = ["dependencies"]
+
+[tool.setuptools]
+py-modules = ["fontio", "terminalio", "paralleldisplay"]
+packages = ["displayio"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}

--- a/terminalio.py
+++ b/terminalio.py
@@ -20,7 +20,7 @@ terminalio for Blinka
 import sys  # pylint: disable=unused-import
 import fontio
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"
 
 FONT = fontio.BuiltinFont()


### PR DESCRIPTION
This was a good candidate for moving to `pyproject.toml` and getting the updated infrastructure as well.

Resolves #96