### PR TITLE
adding blit implementation to Bitmap

### DIFF
--- a/displayio/_bitmap.py
+++ b/displayio/_bitmap.py
@@ -131,7 +131,46 @@ class Bitmap:
     ) -> None:
         # pylint: disable=unnecessary-pass, invalid-name
         """Inserts the source_bitmap region defined by rectangular boundaries"""
-        pass
+        if x2 is None:
+            x2 = source_bitmap.width
+        if y2 is None:
+            y2 = source_bitmap.height
+
+        # Rearrange so that x1 < x2 and y1 < y2
+        if x1 > x2:
+            x1, x2 = x2, x1
+        if y1 > y2:
+            y1, y2 = y2, y1
+
+        # Ensure that x2 and y2 are within source bitmap size
+        x2 = min(x2, source_bitmap.width)
+        y2 = min(y2, source_bitmap.height)
+
+        for y_count in range(y2 - y1):
+            for x_count in range(x2 - x1):
+                x_placement = x + x_count
+                y_placement = y + y_count
+
+                if (self.width > x_placement >= 0) and (
+                    self.height > y_placement >= 0
+                ):  # ensure placement is within target bitmap
+
+                    # get the palette index from the source bitmap
+                    this_pixel_color = source_bitmap[
+                        y1
+                        + (
+                            y_count * source_bitmap.width
+                        )  # Direct index into a bitmap array is speedier than [x,y] tuple
+                        + x1
+                        + x_count
+                    ]
+
+                    if (skip_index is None) or (this_pixel_color != skip_index):
+                        self[  # Direct index into a bitmap array is speedier than [x,y] tuple
+                            y_placement * self.width + x_placement
+                        ] = this_pixel_color
+                elif y_placement > self.height:
+                    break
 
     def dirty(self, x1: int = 0, y1: int = 0, x2: int = -1, y2: int = -1) -> None:
         # pylint: disable=unnecessary-pass, invalid-name


### PR DESCRIPTION
This change adds an implementation for Bitmap.blit(). The specific code was taken and adapted from here: https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/blob/41f06c33ef7a029210416ac61319698f5768e83e/adafruit_display_text/bitmap_label.py#L479-L522

This change is required in order for Blinka_DisplayIO to be able to display BitmapLabel objects. With the empty `pass` implementation this if statement equates to `True` https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/blob/41f06c33ef7a029210416ac61319698f5768e83e/adafruit_display_text/bitmap_label.py#L466 and tries to call bitmap.blit() which doesn't do anything, causing the glyphs not to get copied into the bitmap that is going to be shown on the display.

I tested this change successfully using [Blinka_DisplayIO_PyGameDisplay](https://github.com/foamyguy/Blinka_Displayio_PyGameDisplay) and Raspberry Pi 3 B+