### PR TITLE
Pin Python to 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       id: repo-name
       run: |
         echo ::set-output name=repo-name::Adafruit-Blinka-displayio
-    - name: Set up Python 3.x
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: "3.x"
+        python-version: "3.9"
     - name: Versions
       run: |
         python3 --version


### PR DESCRIPTION
It seems actions isn't working with Python 3.11, so pinning this to an older version since Blinka is targeted at 3.7 anyways.