### PR TITLE
root_group properties/functions on Display object and displaycore.

### DIFF
--- a/displayio/_displaycore.py
+++ b/displayio/_displaycore.py
@@ -151,44 +151,9 @@ class _DisplayCore:
         if self._current_group is not None:
             self._current_group._update_transform(self._transform)
 
-    def show(self, root_group: Group) -> bool:
-        # pylint: disable=protected-access
-
-        """
-        Switches to displaying the given group of layers. When group is `None`, the
-        default CircuitPython terminal will be shown.
-
-        :param Optional[displayio.Group] root_group: The group to show.
-        """
-
-        """
-        # TODO: Implement Supervisor
-        if root_group is None:
-            circuitpython_splash = _Supervisor().circuitpython_splash
-            if not circuitpython_splash._in_group:
-                root_group = circuitpython_splash
-            elif self._current_group == circuitpython_splash:
-                return True
-        """
-
-        if root_group == self._current_group:
-            return True
-
-        if root_group is not None and root_group._in_group:
-            return False
-
-        if self._current_group is not None:
-            self._current_group._in_group = False
-
-        if root_group is not None:
-            root_group._update_transform(self._transform)
-            root_group._in_group = True
-
-        self._current_group = root_group
-        self._full_refresh = True
-
-        print(f"end of show: {root_group}")
-        return True
+    def get_root_group(self):
+        """The root group on the display."""
+        return self._current_group
 
     def set_root_group(self, root_group: Group) -> bool:
         # pylint: disable=protected-access


### PR DESCRIPTION
This change  updates the APIs to match the new core API behavior. 

There is no CIRCUITPYTHON_TERMINAL for Blinka yet so that portion of the behavior is not implemented here either. 

Tested successfully on Raspberry Pi 3B+ with this tester script:
```py
import time
import board
import displayio
import terminalio
from adafruit_display_text.label import Label
import adafruit_ili9341


# Release any resources currently in use for the displays
displayio.release_displays()

spi = board.SPI()
tft_cs = board.CE0
tft_dc = board.D25

display_bus = displayio.FourWire(
    spi, command=tft_dc, chip_select=tft_cs, reset=board.D24
)
display = adafruit_ili9341.ILI9341(display_bus, width=320, height=240, rotation=180)
display.brightness = 0

# Make the display context
splash = displayio.Group()
display.show(splash)

# Draw a green background
color_bitmap = displayio.Bitmap(320, 240, 1)
color_palette = displayio.Palette(1)
color_palette[0] = 0x0055FF  # Bright Green

bg_sprite = displayio.TileGrid(color_bitmap, pixel_shader=color_palette, x=0, y=0)

splash.append(bg_sprite)

# Draw a smaller inner rectangle
inner_bitmap = displayio.Bitmap(280, 200, 1)
inner_palette = displayio.Palette(1)
inner_palette[0] = 0xAA0088  # Purple
inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20, y=20)
splash.append(inner_sprite)

print(inner_palette[0])

# Draw a label
text_group = displayio.Group(scale=3, x=57, y=120)
text = "Blinka\nstuff"
text_area = Label(terminalio.FONT, text=text, color=0xFFFF00)
text_group.append(text_area)  # Subgroup for text scaling
splash.append(text_group)

print(display.root_group)
print(display.root_group == splash)

time.sleep(3)

print("showing none")
display.show(None)

time.sleep(1)

text_area.text = "changed!"
display.root_group = splash

time.sleep(2)

display.root_group = None

time.sleep(1)

display.root_group = displayio.Group()

SHAPE_WIDTH = 100
SHAPE_HEIGHT = 100
shape = displayio.Shape(SHAPE_WIDTH, SHAPE_HEIGHT, mirror_x=True, mirror_y=False)

palette = displayio.Palette(2)

palette[0] = 0x00FFFF  # shape color
palette[1] = 0x00FF00  # shape color

tile_grid = displayio.TileGrid(shape, pixel_shader=palette)

display.root_group.append(tile_grid)

while True:
    pass

```