### PR TITLE
bugfix: prevent reuse of a stopped thread

### DIFF
--- a/displayio/_display.py
+++ b/displayio/_display.py
@@ -394,6 +394,7 @@ class Display:
         elif not value and self._refresh_thread.is_alive():
             # Stop the thread
             self._refresh_thread.join()
+            self._refresh_thread = None
 
     @property
     def brightness(self) -> float:


### PR DESCRIPTION
This fix prevents a thread that was stopped to be restarted.