### PR TITLE
Fix TileGrid flip_x, flip_y and transpose_xy

### DIFF
--- a/displayio/_tilegrid.py
+++ b/displayio/_tilegrid.py
@@ -265,11 +265,11 @@ class TileGrid:
                     ),
                     resample=Image.NEAREST,
                 )
-            if absolute_transform.mirror_x:
+            if absolute_transform.mirror_x != self._flip_x:
                 image = image.transpose(Image.FLIP_LEFT_RIGHT)
-            if absolute_transform.mirror_y:
+            if absolute_transform.mirror_y != self._flip_y:
                 image = image.transpose(Image.FLIP_TOP_BOTTOM)
-            if absolute_transform.transpose_xy:
+            if absolute_transform.transpose_xy != self._transpose_xy:
                 image = image.transpose(Image.TRANSPOSE)
             x *= absolute_transform.dx
             y *= absolute_transform.dy


### PR DESCRIPTION
The != works as an 'xor' condition on the booleans, since each of the transforms is a noop if executed twice.

This works as expected with all my existing CPy code, but I haven't done testing with a parent Group that has its own transform, so the order in which these are applied and possible interactions should still be verified against the native implementation.

Close #106