### PR TITLE
remove ImageFont.getsize() usage for Pillow 10.0.0

### DIFF
--- a/fontio.py
+++ b/fontio.py
@@ -75,7 +75,7 @@ class BuiltinFont:
         """Returns the maximum bounds of all glyphs in the font in
         a tuple of two values: width, height.
         """
-        return self._font.getsize("M")
+        return self._font.getbbox("M")[2:4]
 
     def get_glyph(self, codepoint):
         """Returns a `fontio.Glyph` for the given codepoint or None if no glyph is available."""
@@ -84,7 +84,7 @@ class BuiltinFont:
         else:
             return None
 
-        bounding_box = self._font.getsize(chr(codepoint))
+        bounding_box = self._font.getbbox(chr(codepoint))[2:4]
         width, height = bounding_box
         return Glyph(
             bitmap=self._bitmap,


### PR DESCRIPTION
I think this will resolve the actions error from https://github.com/adafruit/Adafruit_CircuitPython_MatrixPortal/pull/91 as well as other attempts to use Blinka_DisplayIO with Pillow version 10.0.0 which was released recently.

I found the new API to use from the Pillow release notes: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods

The new function returns a tuple with size 4 instead of 2, so I've used slice to make a drop-in replacement for the now removed `getsize()` I confirmed this by adding some print statements to the fontio.py file temporarily.

I did only very minimal testing with the [PyGame Display simpletest script](https://github.com/FoamyGuy/Blinka_Displayio_PyGameDisplay/blob/main/examples/blinka_displayio_pygamedisplay_simpletest.py).



