### PR TITLE
Updated requirements and pre-commit repo versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,21 +4,21 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v0.14.0
+    rev: v1.1.2
     hooks:
     - id: reuse
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pycqa/pylint
-    rev: v2.15.5
+    rev: v2.17.4
     hooks:
     -   id: pylint
         name: pylint (library code)

--- a/displayio/_bitmap.py
+++ b/displayio/_bitmap.py
@@ -154,7 +154,6 @@ class Bitmap:
                 if (self.width > x_placement >= 0) and (
                     self.height > y_placement >= 0
                 ):  # ensure placement is within target bitmap
-
                     # get the palette index from the source bitmap
                     this_pixel_color = source_bitmap[
                         y1

--- a/displayio/_tilegrid.py
+++ b/displayio/_tilegrid.py
@@ -399,7 +399,6 @@ class TileGrid:
 
     @bitmap.setter
     def bitmap(self, new_bitmap: Union[Bitmap, OnDiskBitmap, Shape]) -> None:
-
         if (
             not isinstance(new_bitmap, Bitmap)
             and not isinstance(new_bitmap, OnDiskBitmap)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@
 
 Adafruit-Blinka>=7.0.0
 adafruit-circuitpython-typing
-pillow
-pillow>=6.0.0; python_version>'3.9'
+pillow>=9.2.0
 numpy

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requirements = [
 ]
 
 if sys.version_info > (3, 9):
-    requirements.append("pillow>=6.0.0")
+    requirements.append("pillow>=9.2.0")
 
 # Get the long description from the README file
 with open(path.join(here, "README.rst"), encoding="utf-8") as f:


### PR DESCRIPTION
Fixes #110. #108 fixed displayio for PIL 10.0.0, but did so using a feature that wasn't introduced until 9.2.0. This updates the requirements so that an updated version of PIL is installed.