### PR TITLE
Fix failing docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,14 @@
-# SPDX-FileCopyrightText: 2020 Melissa LeBlanc-Williams for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
 python:
-    version: 3
-requirements_file: requirements.txt
+  version: "3.7"
+  install:
+    - requirements: docs/requirements.txt
+    - requirements: requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+sphinx>=4.0.0


### PR DESCRIPTION
It looks like the docs are failing because the readthedocs.yaml files hadn't been updated. This updates it and adds the correct requirements file for the docs.