### PR TITLE
Use build.os in readthedocs.yaml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,12 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.7"
+
 python:
-  version: "3.7"
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt


### PR DESCRIPTION
It looks like #112 didn't quite work. Looking closer, it now appears to be failing because build.os was missing. I will likely need to make this change on other blinka-related repos.