### PR TITLE
make chip_select pin optional in SPI fourwire

### DIFF
--- a/displayio/_fourwire.py
+++ b/displayio/_fourwire.py
@@ -162,6 +162,8 @@ class FourWire:
         if self._chip_select is not None:
             self._chip_select.value = False
 
+        return True
+
     def _end_transaction(self) -> None:
         """End the SPI transaction by unlocking and setting Chip Select"""
         if self._chip_select is not None:

--- a/displayio/_fourwire.py
+++ b/displayio/_fourwire.py
@@ -74,7 +74,7 @@ class FourWire:
 
         if reset is not None:
             self._reset = digitalio.DigitalInOut(reset)
-            self._reset.switch_to_output(value=False)
+            self._reset.switch_to_output(value=True)
         else:
             self._reset = None
         self._spi = spi_bus

--- a/displayio/_fourwire.py
+++ b/displayio/_fourwire.py
@@ -158,14 +158,9 @@ class FourWire:
         self._spi.configure(
             baudrate=self._frequency, polarity=self._polarity, phase=self._phase
         )
-<<<<<<< HEAD
-        self._chip_select.value = False
-        return True
-=======
 
         if self._chip_select is not None:
             self._chip_select.value = False
->>>>>>> 87a1bde (make chip_select pin optional in SPI four wire)
 
     def _end_transaction(self) -> None:
         """End the SPI transaction by unlocking and setting Chip Select"""


### PR DESCRIPTION
on Odroid C4 the chip_select is controlled by the spi_meson_spicc driver, in case the SPI_CS0 is used as chip_select pin in the FourWire class Resource Busy exceptions are thrown.