### PR TITLE
Bug fixes

### DIFF
--- a/displayio/_display.py
+++ b/displayio/_display.py
@@ -212,7 +212,7 @@ class Display:
                 # 100Hz looks decent and doesn't keep the CPU too busy
                 self._backlight = PWMOut(backlight_pin, frequency=100, duty_cycle=0)
                 self._backlight_type = BACKLIGHT_PWM
-            except ImportError:
+            except (ImportError, NotImplementedError):
                 # PWMOut not implemented on this platform
                 pass
             if self._backlight_type is None:

--- a/displayio/_fourwire.py
+++ b/displayio/_fourwire.py
@@ -75,6 +75,7 @@ class FourWire:
         if reset is not None:
             self._reset = digitalio.DigitalInOut(reset)
             self._reset.switch_to_output(value=True)
+            self.reset()
         else:
             self._reset = None
         self._spi = spi_bus


### PR DESCRIPTION
This automatically calls reset on the display which makes it work better. This also checks for NotImplementedError for pwmio, which I will need to update on Blinka (https://github.com/adafruit/Adafruit_Blinka/pull/785) as it is currently not working on the Pi 5. This allows the ST7789 to now work on the Pi 5.