### PR TITLE
Fix pyproject.toml packages to match setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ classifiers = [
 dynamic = ["dependencies"]
 
 [tool.setuptools]
-py-modules = ["fontio", "terminalio", "paralleldisplay"]
-packages = ["displayio", "vectorio"]
+py-modules = ["fontio", "terminalio"]
+packages = ["displayio", "vectorio", "paralleldisplaybus", "i2cdisplaybus", "fourwire", "busdisplay"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
I noticed the new split packages were not being installed. It's because I forgot we have pyproject.toml to update now too.