### PR TITLE
Add missing epaperdisplay package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = ["dependencies"]
 
 [tool.setuptools]
 py-modules = ["fontio", "terminalio"]
-packages = ["displayio", "vectorio", "paralleldisplaybus", "i2cdisplaybus", "fourwire", "busdisplay"]
+packages = ["displayio", "vectorio", "paralleldisplaybus", "i2cdisplaybus", "fourwire", "busdisplay", "epaperdisplay"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,6 @@ setup(
         "i2cdisplaybus",
         "fourwire",
         "busdisplay",
+        "epaperdisplay",
     ],
 )


### PR DESCRIPTION
epaperdisplay was missing from the package list on both `setup.py` and `pyproject.toml`.