### PR TITLE
8.x backward compatibility

### DIFF
--- a/displayio/__init__.py
+++ b/displayio/__init__.py
@@ -18,6 +18,8 @@ displayio for Blinka
 """
 import threading
 from typing import Union
+
+import fourwire
 from busdisplay import BusDisplay
 from busdisplay._displaybus import _DisplayBus
 from epaperdisplay import EPaperDisplay
@@ -29,6 +31,11 @@ from ._ondiskbitmap import OnDiskBitmap
 from ._palette import Palette
 from ._tilegrid import TileGrid
 from ._constants import CIRCUITPY_DISPLAY_LIMIT
+
+# 8.x Backwards compatibility, remove at 10.x or
+# when compatibility is removed from core displayio
+Display = BusDisplay
+FourWire = fourwire.FourWire
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_displayio.git"


### PR DESCRIPTION
I have not tested on hardware. 

I think this will work as a solution for https://github.com/adafruit/Adafruit_CircuitPython_SSD1322/issues/21 to allow that display driver and a few others to work under blinka displayio.