### PR TITLE
A work-around for using byte-string as the data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bundles
 dist
 **/*.egg-info
 .vscode
+venv
+.venv

--- a/i2cdisplaybus/__init__.py
+++ b/i2cdisplaybus/__init__.py
@@ -86,10 +86,14 @@ class I2CDisplayBus:
         such as vertical scroll, set via ``send`` may or may not be reset once the code is
         done.
         """
+
+        # prepend the command to the data buffer
+        buffer = bytearray(len(data) + 1)
+        buffer[0] = command & 0xFF
+        buffer[1:] = data
+
         self._begin_transaction()
-        # re-wrap in case of byte-string
-        buffer = list(data) if isinstance(data, bytes) else data
-        self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, bytes([command] + buffer))
+        self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, buffer)
         self._end_transaction()
 
     def _send(

--- a/i2cdisplaybus/__init__.py
+++ b/i2cdisplaybus/__init__.py
@@ -87,7 +87,9 @@ class I2CDisplayBus:
         done.
         """
         self._begin_transaction()
-        self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, bytes([command] + data))
+        # re-wrap in case of byte-string
+        buffer = list(data) if isinstance(data, bytes) else data
+        self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, bytes([command] + buffer))
         self._end_transaction()
 
     def _send(


### PR DESCRIPTION
Fixes #137 -- a byte-string is not representable as a `list` for adding, so this just re-wraps the iterable in a "real" `list`

This is the code used to verify that the outputs are similar for both 4-Wire and I2C (as that was the easiest to compare to).

```python
from circuitpython_typing import ReadableBuffer

def pretty_print(prefix, data):
    hex_code = "".join(["%02X " % x for x in data])
    print(f"{prefix} {hex_code}\n")

def i2c_usage(command: int, data: ReadableBuffer):
    buffer = list(data) if isinstance(data, bytes) else data
    sent_this = bytes([command] + buffer)
    pretty_print("i2c", sent_this)

def four_wire(command: int, data: ReadableBuffer):
    b = bytes([command])
    pretty_print("4-cmd", b)
    pretty_print("4-buffer", data)

# SSD1036 "sleep"
# 2.0.2
print("My change-----------------")
four_wire(0xAE, [])
i2c_usage(0xAE, [])

four_wire(0xAE, [1,2,3])
i2c_usage(0xAE, [1,2,3])


# 2.0.1
print("Old usage-----------------")
four_wire(0xAE,b"")
# i2c_usage(0xAE,b"")

four_wire(0xAE, b"123")
i2c_usage(0xAE, b"123")
```
