### PR TITLE
avoid ZeroDivisionError with ssd1327

### DIFF
--- a/busdisplay/__init__.py
+++ b/busdisplay/__init__.py
@@ -366,6 +366,8 @@ class BusDisplay:
                 pixels_per_byte = 8 // self._core.colorspace.depth
                 if rows_per_buffer % pixels_per_byte != 0:
                     rows_per_buffer -= rows_per_buffer % pixels_per_byte
+            if rows_per_buffer == 0:
+                rows_per_buffer = 1
             subrectangles = clipped.height() // rows_per_buffer
             if clipped.height() % rows_per_buffer != 0:
                 subrectangles += 1


### PR DESCRIPTION
For a ssd1327 rows_per_buffer is 104/106, which rounds/truncates to zero, causing ZeroDivisionError on line 371 (subrectangles=...).

Tested with a ssd1327 on raspberry pi 4.