### PR TITLE
I2c buffer sleepwake fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bundles
 dist
 **/*.egg-info
 .vscode
+venv
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,3 @@ bundles
 dist
 **/*.egg-info
 .vscode
-venv
-.venv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,17 +102,7 @@ napoleon_numpy_docstring = False
 #
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
-    except:
-        html_theme = "default"
-        html_theme_path = ["."]
-else:
-    html_theme_path = ["."]
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/i2cdisplaybus/__init__.py
+++ b/i2cdisplaybus/__init__.py
@@ -89,9 +89,6 @@ class I2CDisplayBus:
         done.
         """
         self._begin_transaction()
-        # re-wrap in case of byte-string
-        #buffer = list(data) if isinstance(data, bytes) else data
-        #self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, bytes([command] + buffer))
         self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, data, command)
         self._end_transaction()
 

--- a/i2cdisplaybus/__init__.py
+++ b/i2cdisplaybus/__init__.py
@@ -99,6 +99,7 @@ class I2CDisplayBus:
         data: ReadableBuffer,
         command: Optional[int] = None,
     ):
+        # pylint: disable=too-many-branches
         if data_type == DISPLAY_COMMAND:
             n = len(data)
             if command is not None:

--- a/i2cdisplaybus/__init__.py
+++ b/i2cdisplaybus/__init__.py
@@ -87,7 +87,9 @@ class I2CDisplayBus:
         done.
         """
         self._begin_transaction()
-        self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, bytes([command] + data))
+        # re-wrap in case of byte-string
+        buffer = list(data) if isinstance(data, bytes) else data
+        self._send(DISPLAY_COMMAND, CHIP_SELECT_UNTOUCHED, bytes([command] + buffer))
         self._end_transaction()
 
     def _send(


### PR DESCRIPTION
@ladyada 

Resolves: #137. This implements the changes suggested in #138 as I understand them.

I tested this version successfully with the SSD1306 and confirmed that the sleep/wake are working as expected using the reproducer from here: https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SSD1306/issues/47

I also tested simpletest and a few variations of it to ensure the display is initializing and drawing correctly and everything appears to behave normally to me.

Should also resolve: 
- https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SSD1306/issues/47
- https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SH1106/issues/21 (The only SSH1106 I have is on the macropad and I don't know if possible / how to test it with RPi.)

Also removed the `get_html_theme()` call from the docs config which is deprecated and how raises an error when building the docs.