### PR TITLE
smol sleep inside background loop

### DIFF
--- a/displayio/__init__.py
+++ b/displayio/__init__.py
@@ -17,6 +17,7 @@ displayio for Blinka
 
 """
 import threading
+import time
 from typing import Union
 
 import fourwire
@@ -52,6 +53,7 @@ def _background():
     while True:
         for display in displays:
             display._background()  # pylint: disable=protected-access
+        time.sleep(0.001)
 
 
 def release_displays() -> None:


### PR DESCRIPTION
Intended to resolve: https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_SSD1306/issues/48

This `while True:` loop runs very fast and revs one of the CPU cores even while the display isn't being refreshed. A tiny sleep inside of it appears to keep the CPU usage much lower watching `htop` while doing `import displayio` in REPL and running ssd1306 simpletest. 

Needs more robust testing still, so far I've only used it on SSD1306 for a quick proof of concept and to check htop. I'll mark this as ready once I've tested SPI displays and more thoroughly in general. 

@makermelissa does it make sense to you to have a small sleep inside of this background loop?