### PR TITLE
Accept 65536 colors bitmaps

### DIFF
--- a/displayio/_bitmap.py
+++ b/displayio/_bitmap.py
@@ -57,8 +57,8 @@ class Bitmap:
         the Bitmap.
         """
 
-        if not 1 <= value_count <= 65535:
-            raise ValueError("value_count must be in the range of 1-65535")
+        if not 1 <= value_count <= 65536:
+            raise ValueError("value_count must be in the range of 1-65536")
 
         bits = 1
         while (value_count - 1) >> bits:


### PR DESCRIPTION
This now matches Circuitpython:
https://github.com/adafruit/circuitpython/blob/db4f0596abe2db49520c5e3930816ab93d66e148/shared-bindings/displayio/Bitmap.c#L46

I ran into that trying to make adafruit_imageload work with blinka .
https://github.com/adafruit/Adafruit_CircuitPython_ImageLoad/blob/c36419bcc430f33d4ec208fd290cc815d65724ab/adafruit_imageload/png.py#L127