### PR TITLE
convert tuple to hex color first

### DIFF
--- a/displayio/_colorconverter.py
+++ b/displayio/_colorconverter.py
@@ -206,7 +206,14 @@ class ColorConverter:
             self._cached_output_color = output_color.pixel
 
     @staticmethod
+    def _rgbtuple_to_hex(color_tuple):
+        """Convert rgb tuple with 0-255 values to hex color value"""
+        return color_tuple[0] << 16 | color_tuple[1] << 8 | color_tuple[2]
+
+    @staticmethod
     def _convert_pixel(colorspace: Colorspace, pixel: int) -> int:
+        if isinstance(pixel, tuple):
+            pixel = ColorConverter._rgbtuple_to_hex(pixel)
         pixel = clamp(pixel, 0, 0xFFFFFFFF)
         if colorspace in (
             Colorspace.RGB565_SWAPPED,


### PR DESCRIPTION
@ladyada 
Resolves: #145 

`clamp()` and the rest of convert_pixel assume that `pixel` will be a hex value, but in some cases they come in as color tuple. This converts them to hex before continuing. I tested this fix successfully with a ILI9341 on Pi4 with a modified version of the png test script from examples in the ImageLoad repo examples. I also tested ili9341_pitft_simpletest.py to ensure this change doesn't cause any issues for non-imageload usage. 