### PR TITLE
Refresh Fix for TileGrid

### DIFF
--- a/displayio/_bitmap.py
+++ b/displayio/_bitmap.py
@@ -199,10 +199,6 @@ class Bitmap:
             elif bytes_per_value == 4:
                 struct.pack_into("<I", row, x * 4, value)
 
-    def _finish_refresh(self):
-        self._dirty_area.x1 = 0
-        self._dirty_area.x2 = 0
-
     def fill(self, value: int) -> None:
         """Fills the bitmap with the supplied palette index value."""
         if self._read_only:


### PR DESCRIPTION
@ladyada 
Resolves: #150 

I believe the root cause of the issue is the refresh thread running on it's own cycle in the background while the user code is manipulating Groups, TileGrids, Bitmaps etc. which cause refresh to be needed.  I think there is a period of time during the refresh process after `_get_refresh_areas()` has been called for a given object, and before `_finish_refresh()` gets called for that same object. During that window of time if the user code manipulates the object making it need to be re-drawn it won't actually get drawn because `_finish_refresh()` gets called first which makes the next call to `_get_refresh_areas()` not return any areas to draw because `_finish_refresh()` clears / resets the dirty area to empty.

This change resolves it by adding a `_needs_refresh` bool that gets set to True whenever any change that triggers a refresh occurs. Then inside `_finish_refresh()` we only do the finish logic when that bool is False. The bool is flopped to False in `_get_refresh_areas()` once we know that our triggered refresh is in process. 

I tested this fix successfully with the reproducer from the issue. 

Unrelated to the issue above, I also removed a duplicated `_finish_refresh()` function inside of Bitmap. The remaining function is here: https://github.com/adafruit/Adafruit_Blinka_Displayio/blob/main/displayio/_bitmap.py#L294 