### PR TITLE
update docs build reqs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,6 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-sphinx>=4.0.0
+sphinx
+sphinxcontrib-jquery
+sphinx-rtd-theme


### PR DESCRIPTION
@ladyada 
I think this will resolve: #151 

Updated docs requirements to match the ones in library repos e.g. https://github.com/adafruit/Adafruit_CircuitPython_CCS811/blob/main/docs/requirements.txt 

I was able to make a local docs build successfully after `pip install -r docs/requirements.txt --upgrade`  with these changes.