### PR TITLE
declare sphinx.configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,6 +7,9 @@
 # Required
 version: 2
 
+sphinx:
+  configuration: docs/conf.py
+
 build:
   os: "ubuntu-20.04"
   tools:


### PR DESCRIPTION
This is required by RTD now https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

We used adabot recently to patch many libraries with this fix, but it doesn't do the Blinka one it seems. 