### PR TITLE
relax displayio._background thread

### DIFF
--- a/displayio/__init__.py
+++ b/displayio/__init__.py
@@ -17,6 +17,7 @@ displayio for Blinka
 
 """
 import threading
+import time
 from typing import Union
 
 import fourwire
@@ -47,11 +48,15 @@ displays = []
 display_buses = []
 
 
-def _background():
+def _background(stop_event):
     """Main thread function to loop through all displays and update them"""
-    while True:
+    while not stop_event.is_set():
         for display in displays:
             display._background()  # pylint: disable=protected-access
+    
+        # relax system when _background does nothing 
+        # and we are in a while True loop consuming lots of CPU
+        time.sleep(0.0)
 
 
 def release_displays() -> None:
@@ -85,7 +90,8 @@ def allocate_display_bus(new_display_bus: _DisplayBus) -> None:
     display_buses.append(new_display_bus)
 
 
-background_thread = threading.Thread(target=_background, daemon=True)
+background_thread_stop_event = threading.Event()
+background_thread = threading.Thread(target=_background,args=(background_thread_stop_event,), daemon=True)
 
 
 # Start the background thread
@@ -96,6 +102,7 @@ def _start_background():
 
 def _stop_background():
     if background_thread.is_alive():
+        background_thread_stop_event.set()
         # Stop the thread
         background_thread.join()
 


### PR DESCRIPTION
### Issue

The background thread inside displayio which is started automatically consumes a lot of CPU.


The `while True` loop has nothing to relax the system:
- at startup there are no displays, so it is a pure `while True` consume 100% CPU
- when a display is added, there is not much logic inside the `display._background()` that relaxes the system, so we have near 100% CPU
- when `auto_refresh` is set to `False`, the `display._background()` returns immediately and there is nothing to relax the system causing 100% CPU

Besides this there is no way to actually stop the background thread, the join method in `_stop_background()` is waiting forever.

### Fix
- a `time.sleep(0.0)` has been added to relax the system a bit. 
- an `Event()` is added to the `Thread` in that can be set to actually stop the background thread.

